### PR TITLE
Fixed link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@ XRG
 
 A system monitor for macOS.
 
-http://www.gauchosoft.com/xrg/
+http://www.gauchosoft.com/xrg


### PR DESCRIPTION
Had an extra `/` at the end that was screwing things up.