### PR TITLE
TemperatureMiner : fix display order

### DIFF
--- a/Data Miners/XRGTemperatureMiner.m
+++ b/Data Miners/XRGTemperatureMiner.m
@@ -332,15 +332,21 @@
 			}
 		}
 		
-		[locationKeysInOrder addObjectsFromArray:[tmpCPUCore sortedArrayUsingSelector:@selector(caseInsensitiveCompare:)]];
-		[locationKeysInOrder addObjectsFromArray:[tmpCPUA sortedArrayUsingSelector:@selector(caseInsensitiveCompare:)]];
-		[locationKeysInOrder addObjectsFromArray:[tmpCPUB sortedArrayUsingSelector:@selector(caseInsensitiveCompare:)]];
-		[locationKeysInOrder addObjectsFromArray:[tmpCPU sortedArrayUsingSelector:@selector(caseInsensitiveCompare:)]];
-		[locationKeysInOrder addObjectsFromArray:[tmpGPU sortedArrayUsingSelector:@selector(caseInsensitiveCompare:)]];
-		[locationKeysInOrder addObjectsFromArray:[tmpU3 sortedArrayUsingSelector:@selector(caseInsensitiveCompare:)]];
-		[locationKeysInOrder addObjectsFromArray:[tmpBattery sortedArrayUsingSelector:@selector(caseInsensitiveCompare:)]];
-		[locationKeysInOrder addObjectsFromArray:[tmpDrive sortedArrayUsingSelector:@selector(caseInsensitiveCompare:)]];
-		[locationKeysInOrder addObjectsFromArray:[tmpOthers sortedArrayUsingSelector:@selector(caseInsensitiveCompare:)]];
+        NSSortDescriptor *descriptor = [NSSortDescriptor sortDescriptorWithKey:@"self"
+                                                                         ascending:YES
+                                                                        comparator:^(id obj1, id obj2) {
+                                                                            return [obj1 compare:obj2 options:NSNumericSearch];
+                                                                        }];
+        
+		[locationKeysInOrder addObjectsFromArray:[tmpCPUCore sortedArrayUsingDescriptors:@[descriptor]]];
+		[locationKeysInOrder addObjectsFromArray:[tmpCPUA sortedArrayUsingDescriptors:@[descriptor]]];
+		[locationKeysInOrder addObjectsFromArray:[tmpCPUB sortedArrayUsingDescriptors:@[descriptor]]];
+		[locationKeysInOrder addObjectsFromArray:[tmpCPU sortedArrayUsingDescriptors:@[descriptor]]];
+		[locationKeysInOrder addObjectsFromArray:[tmpGPU sortedArrayUsingDescriptors:@[descriptor]]];
+		[locationKeysInOrder addObjectsFromArray:[tmpU3 sortedArrayUsingDescriptors:@[descriptor]]];
+		[locationKeysInOrder addObjectsFromArray:[tmpBattery sortedArrayUsingDescriptors:@[descriptor]]];
+		[locationKeysInOrder addObjectsFromArray:[tmpDrive sortedArrayUsingDescriptors:@[descriptor]]];
+		[locationKeysInOrder addObjectsFromArray:[tmpOthers sortedArrayUsingDescriptors:@[descriptor]]];
 	}
 	
 	free(alreadyUsed);


### PR DESCRIPTION
Using the NSNumericSearch instead of the caseInsensitiveCompare to sort the temperatures that are displayed.

<img width="334" alt="Screenshot 2019-08-01 at 17 04 49" src="https://user-images.githubusercontent.com/5154754/62305837-fde57e00-b480-11e9-97cc-1c167e937dea.png">
<img width="333" alt="Screenshot 2019-08-01 at 17 03 57" src="https://user-images.githubusercontent.com/5154754/62305838-fde57e00-b480-11e9-96f0-88067eb602eb.png">

